### PR TITLE
Use PSScriptRoot to determine repo root and update paths

### DIFF
--- a/localContainers/scripts/init.ps1
+++ b/localContainers/scripts/init.ps1
@@ -23,6 +23,9 @@ Param (
 
 $ErrorActionPreference = "Stop";
 
+# Set the root of the repository
+$RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
+
 if ($InitEnv) {
     if (-not $LicenseXmlPath.EndsWith("license.xml")) {
         Write-Error "Sitecore license file must be named 'license.xml'."
@@ -65,7 +68,7 @@ Write-SitecoreDockerWelcome
 # Configure TLS/HTTPS certificates
 ##################################
 
-Push-Location ..\docker\traefik\certs
+Push-Location $RepoRoot\localContainers\docker\traefik\certs
 try {
     $mkcert = ".\mkcert.exe"
     if ($null -ne (Get-Command mkcert.exe -ErrorAction SilentlyContinue)) {
@@ -94,6 +97,7 @@ finally {
     Pop-Location
 }
 
+$envFileLocation = "$RepoRoot/localContainers/.env"
 
 ################################
 # Add Windows hosts file entries
@@ -108,20 +112,20 @@ Add-HostsEntry "www.nextjs-starter.localhost"
 # Generate scjssconfig
 ###############################
 
-Set-EnvFileVariable "SITECORE_API_KEY_NEXTJS_STARTER" -Value $xmCloudBuild.renderingHosts.nextjsStarter.jssDeploymentSecret -Path "../.env"
+Set-EnvFileVariable "SITECORE_API_KEY_NEXTJS_STARTER" -Value $xmCloudBuild.renderingHosts.nextjsStarter.jssDeploymentSecret -Path $envFileLocation
 
 ################################
 # Generate Sitecore Api Key
 ################################
 
 $sitecoreApiKey = (New-Guid).Guid
-Set-EnvFileVariable "SITECORE_API_KEY_NEXTJS_STARTER" -Value $sitecoreApiKey -Path "../.env"
+Set-EnvFileVariable "SITECORE_API_KEY_NEXTJS_STARTER" -Value $sitecoreApiKey -Path $envFileLocation
 
 ################################
 # Generate JSS_EDITING_SECRET
 ################################
 $jssEditingSecret = Get-SitecoreRandomString 64 -DisallowSpecial
-Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret -Path "../.env"
+Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret -Path $envFileLocation
 
 ###############################
 # Populate the environment file
@@ -129,50 +133,52 @@ Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret -Path "../.env
 
 if ($InitEnv) {
 
+    
+
     Write-Host "Populating required .env file values..." -ForegroundColor Green
 
     # HOST_LICENSE_FOLDER
-    Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath -Path "../.env"
+    Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath -Path $envFileLocation
 
     # CM_HOST
-    Set-EnvFileVariable "CM_HOST" -Value "xmcloudcm.localhost" -Path "../.env"
+    Set-EnvFileVariable "CM_HOST" -Value "xmcloudcm.localhost" -Path $envFileLocation
 
     # RENDERING_HOST
-    Set-EnvFileVariable "RENDERING_HOST" -Value "www.nextjs-starter.localhost" -Path "../.env"
+    Set-EnvFileVariable "RENDERING_HOST" -Value "www.nextjs-starter.localhost" -Path $envFileLocation
 
     # REPORTING_API_KEY = random 64-128 chars
-    Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial) -Path "../.env"
+    Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial) -Path $envFileLocation
 
     # TELERIK_ENCRYPTION_KEY = random 64-128 chars
-    Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial) -Path "../.env"
+    Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial) -Path $envFileLocation
 
     # MEDIA_REQUEST_PROTECTION_SHARED_SECRET
-    Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64) -Path "../.env"
+    Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64) -Path $envFileLocation
 
     # SQL_SA_PASSWORD
     # Need to ensure it meets SQL complexity requirements
-    Set-EnvFileVariable "SQL_SA_PASSWORD" -Value (Get-SitecoreRandomString 19 -DisallowSpecial -EnforceComplexity) -Path "../.env"
+    Set-EnvFileVariable "SQL_SA_PASSWORD" -Value (Get-SitecoreRandomString 19 -DisallowSpecial -EnforceComplexity) -Path $envFileLocation
 
     # SQL_SERVER
-    Set-EnvFileVariable "SQL_SERVER" -Value "mssql" -Path "../.env"
+    Set-EnvFileVariable "SQL_SERVER" -Value "mssql" -Path $envFileLocation
 
     # SQL_SA_LOGIN
-    Set-EnvFileVariable "SQL_SA_LOGIN" -Value "sa" -Path "../.env"
+    Set-EnvFileVariable "SQL_SA_LOGIN" -Value "sa" -Path $envFileLocation
 
     # SITECORE_ADMIN_PASSWORD
-    Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $AdminPassword -Path "../.env"
+    Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $AdminPassword -Path $envFileLocation
 
     # SITECORE_VERSION
-    Set-EnvFileVariable "SITECORE_VERSION" -Value "1-$baseOS" -Path "../.env"
+    Set-EnvFileVariable "SITECORE_VERSION" -Value "1-$baseOS" -Path $envFileLocation
 
     # EXTERNAL_IMAGE_TAG_SUFFIX
-    Set-EnvFileVariable "EXTERNAL_IMAGE_TAG_SUFFIX" -Value $baseOS -Path "../.env"
+    Set-EnvFileVariable "EXTERNAL_IMAGE_TAG_SUFFIX" -Value $baseOS -Path $envFileLocation
 }
 
 Write-Host "Done!" -ForegroundColor Green
 
 Pop-Location
-Push-Location ..\docker\traefik\certs
+Push-Location $RepoRoot\localContainers\docker\traefik\certs
 try
 {
     Write-Host


### PR DESCRIPTION
Updated the init.ps1 script to determine the root of the cloned repository using PSScriptRoot and updated relative paths to use the `RepoRoot` variable. Now allows the init.ps1 scrip to run from multiple folder

from root:

```ps1
./localContainers/scripts/init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
```

or from localContainers folder like:

```ps1
./scripts/init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
```
